### PR TITLE
Fix disabling of text input for non required color fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,10 +71,9 @@
       // Load published value from CDA.
       loadPublishedValue(entry.getSys().id)
           .then(function (entries) {
-                console.log(JSON.stringify(entries))
-                publishedValue = entries.items[0].fields[fieldId][fieldLocale];
                 draftTextEl.disabled = false;
                 colourPickerEl.disabled = false;
+                publishedValue = entries.items[0].fields[fieldId][fieldLocale];
                 renderColour();
               }
           )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "colourpicker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Colour picker UI extension for Contentful's web app.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Summary:
When a color is not defined, text field gets disabled which makes it harder to copy a hex value

Changes:
- Moved enabling text and color input before throwing the error
- Removed unnecessary console.log